### PR TITLE
fix: translations, leader display improvements

### DIFF
--- a/addons/sourcemod/scripting/nominations_extended.sp
+++ b/addons/sourcemod/scripting/nominations_extended.sp
@@ -45,7 +45,7 @@
 #include <basecomm>
 #include <multicolors>
 
-#define NE_VERSION "1.3.4"
+#define NE_VERSION "1.3.5"
 
 public Plugin myinfo =
 {

--- a/addons/sourcemod/scripting/nominations_extended.sp
+++ b/addons/sourcemod/scripting/nominations_extended.sp
@@ -1207,6 +1207,13 @@ public int Handler_MapSelectMenu(Menu menu, MenuAction action, int param1, int p
 				return RedrawMenuItem(buffer);
 			}
 
+			#if defined _zleader_included
+			if(RestrictionsActive && LeaderRestriction)
+			{
+				return RedrawMenuItem(buffer);
+			}
+			#endif
+
 			if(mark && !official)
 				return RedrawMenuItem(buffer);
 

--- a/addons/sourcemod/translations/mapchooser_extended.phrases.txt
+++ b/addons/sourcemod/translations/mapchooser_extended.phrases.txt
@@ -116,10 +116,20 @@
 	{
 		"en"		"VIP"
 	}
+    
+    "Leader Nomination"
+	{
+		"en"		"Leader"
+	}
 
 	"Map Nominate VIP Error"
 	{
 		"en"		"Only VIPs can nominate this map."
+	}
+    
+    "Map Nominate Leader Error"
+	{
+		"en"		"Only Leaders can nominate this map."
 	}
 
 	"Map Nominate Time Error"
@@ -167,6 +177,11 @@
 	"VIP Restriction"
 	{
 		"en"		"VIP only"
+	}
+    
+    "Leader Restriction"
+	{
+		"en"		"Leader only"
 	}
 
 	"Nomination Removed Time Error"


### PR DESCRIPTION
Print "(Leader only)" in the nomation list maps
During map vote print "de_dust2 (Leader)"
Missing translations
![image](https://github.com/srcdslab/sm-plugin-mapchooser_extended/assets/11679883/a096f676-ceed-4771-82bb-b676e436efd5)
![image](https://github.com/srcdslab/sm-plugin-mapchooser_extended/assets/11679883/3656d4d9-7e62-4b88-a121-f351ecd5a45e)
![image](https://github.com/srcdslab/sm-plugin-mapchooser_extended/assets/11679883/bd783fdc-0b8c-4d8d-8a4c-9f3c300ea8e5)
